### PR TITLE
Change the default search engine to searX

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,9 +1,9 @@
 ---
 layout: default
 ---
-<form id="searchForm" class="input-group input-group-lg" action="https://google.com/search" method="GET">
+<form id="searchForm" class="input-group input-group-lg" action="https://searx.xyz/" method="GET">
 	<div class="dropdown mx-auto mb-2">
-		<button class="btn btn-lg border border-right-0 search-engine" type="button" id="dropdownMenuButton" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false"><img id="sel" src="{{ "/assets/search/google.svg" | relative_url }}" alt="Google"/></button>
+		<button class="btn btn-lg border border-right-0 search-engine" type="button" id="dropdownMenuButton" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false"><img id="sel" src="{{ "/assets/search/searx.svg" | relative_url }}" alt="Searx"/></button>
 		<div class="dropdown-menu" aria-labelledby="dropdownMenuButton">
 			{% for entry in site.data.search-engines %}
 				<a class="dropdown-item" href="#" onclick="saveSearch('{{ entry.key }}');"><img class="mr-2" src="{{ "/assets/search/" | relative_url }}{{ entry.image }}"/>{{ entry.name }}</a>


### PR DESCRIPTION
This commit changes the default search engine to searx, a privacy-respecting metasearch engine. Google are known for invasive privacy, limiting freedom, and censorship of information. I do not think it's wise to direct users to a dangerous search engine as a default feature. Instead, let's start them off with a safer option.