### PR TITLE
Fix description

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,7 +1,7 @@
 title: openSUSE Search
 title_short: Search
 description: >-
-  Search the openSUSE infrastructure
+  Search the web, with openSUSE Search
 copyright: '© 2011–2020 openSUSE contributors'
 piwik_site_id: 5
 url: "https://search.opensuse.org/"


### PR DESCRIPTION
openSUSE Search doesn't really search the openSUSE infra... I guess the header and footer are infra-related but still

Signed-off-by: Odyssey346 <odyssey346@disroot.org>