### PR TITLE
new year 2022 added to footer

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -6,7 +6,7 @@
 			<a href="https://en.opensuse.org/Sponsors"><img src="{{ "/assets/images/" | relative_url }}{{ site.data.sponsors[random].image }}" title="Project sponsored by {{ site.data.sponsors[random].name }}" alt="{{ site.data.sponsors[random].name }}" class="sponsor-logo-small mr-3"></a>
 		</div>
 		<div class="col-12 col-md-4 text-center my-auto">
-			<span>&copy; 2011&ndash;2020</span> <span lang="en">openSUSE contributors</span>
+			<span>&copy; 2011&ndash;2022</span> <span lang="en">openSUSE contributors</span>
 		</div>
 		<div class="col-12 col-md-4 text-md-right text-center my-auto">
 				<div class="btn-group dropup">


### PR DESCRIPTION
Saw that on https://search.opensuse.org it still said 2020