### PR TITLE
Removed Givero Search Engine

### DIFF
--- a/_data/search-engines.yml
+++ b/_data/search-engines.yml
@@ -13,10 +13,8 @@
   image: ecosia.svg
   url: https://www.ecosia.org/search
 
-- name: Givero
-  key: givero
-  image: givero.svg
-  url: https://www.givero.com/search
+# Removed Givero Search as it is discontinued
+# Any good Replacements for it?
 
 - name: Google
   key: google


### PR DESCRIPTION
Sadly as [(https://www.givero.com/)] has been discontinued, It has been removed from the list of search engines.
