### PR TITLE
Repair mailing list search

### DIFF
--- a/lists.html
+++ b/lists.html
@@ -3,7 +3,7 @@ layout: search
 permalink: /lists/
 ---
 <form id="lists" method="get" action="https://lists.opensuse.org/cgi-bin/search.cgi" class="input-group input-group-lg" > 
-	<input id="searchbox" type="text" name="query" value="" lang="en" placeholder="Search Mailing Lists" class="form-control w-auto mx-auto mb-2 mr-md-2"/>
+	<input id="searchbox" type="text" name="q" value="" lang="en" placeholder="Search Mailing Lists" class="form-control w-auto mx-auto mb-2 mr-md-2"/>
 	<select id="lists-options" class="custom-select mx-auto mb-2 mr-md-2" name="list">
 		<option value="all" selected="selected">All</option>
 		<option value="heroes">heroes</option>

--- a/lists.html
+++ b/lists.html
@@ -2,7 +2,7 @@
 layout: search
 permalink: /lists/
 ---
-<form id="lists" method="get" action="http://lists.opensuse.org/cgi-bin/search.cgi" class="input-group input-group-lg" > 
+<form id="lists" method="get" action="https://lists.opensuse.org/cgi-bin/search.cgi" class="input-group input-group-lg" > 
 	<input id="searchbox" type="text" name="query" value="" lang="en" placeholder="Search Mailing Lists" class="form-control w-auto mx-auto mb-2 mr-md-2"/>
 	<select id="lists-options" class="custom-select mx-auto mb-2 mr-md-2" name="list">
 		<option value="all" selected="selected">All</option>


### PR DESCRIPTION
Hi,

Currently https://search.opensuse.org/lists/ shows two bugs for me:

- Modern browser (Firefox) complains about the form being transmitted insecurely
- Transmitted search queries seem to always yield zero results, even with queries like `vim`, which one would expect to get many results for

This patch addresses both issues using the following solutions:

- Use https endpoint instead of plain http
- Change query from `query` to `q` which matches the query being sent when using the search field on https://lists.opensuse.org directly

Best,
Georg