### PR TITLE
add libffi-devel to dependencies to solve gem bundler dependencies in…

### DIFF
--- a/.github/workflows/translations.yml
+++ b/.github/workflows/translations.yml
@@ -14,7 +14,7 @@ jobs:
 
     steps:
     - name: Install dependencies
-      run: zypper install -y tar gzip ruby-devel "rubygem(bundler)" gcc-c++ gettext-tools make zlib-devel git-core libxml2-devel libxslt-devel
+      run: zypper install -y tar gzip ruby-devel "rubygem(bundler)" gcc-c++ gettext-tools make zlib-devel git-core libxml2-devel libxslt-devel libffi-devel
 
     - uses: actions/checkout@v2
 


### PR DESCRIPTION
add libffi-devel to dependencies to solve gem bundler dependencies install problems
Error suggests this

```
Gem::Ext::BuildError: ERROR: Failed to build gem native extension.

current directory:
/__w/search-o-o/search-o-o/.bundle/ruby/3.2.0/gems/ffi-1.15.5/ext/ffi_c
/usr/bin/ruby.ruby3.2 extconf.rb
checking for ffi.h... no
checking for ffi.h in
/usr/local/include,/usr/include/ffi,/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/include/ffi,/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/ffi...
no
checking for whether -Wl,--exclude-libs,ALL is accepted as LDFLAGS... yes
checking for whether -pthread is accepted as LDFLAGS... yes
creating extconf.h
creating Makefile

current directory:
/__w/search-o-o/search-o-o/.bundle/ruby/3.2.0/gems/ffi-1.15.5/ext/ffi_c
make DESTDIR\= sitearchdir\=./.gem.20240116-465-3tld5a
sitelibdir\=./.gem.20240116-465-3tld5a clean

current directory:
/__w/search-o-o/search-o-o/.bundle/ruby/3.2.0/gems/ffi-1.15.5/ext/ffi_c
make DESTDIR\= sitearchdir\=./.gem.20240116-465-3tld5a
sitelibdir\=./.gem.20240116-465-3tld5a
Configuring libffi
/__w/search-o-o/search-o-o/.bundle/ruby/3.2.0/gems/ffi-1.15.5/ext/ffi_c/libffi/configure:
line 11473: awk: command not found
/__w/search-o-o/search-o-o/.bundle/ruby/3.2.0/gems/ffi-1.15.5/ext/ffi_c/libffi/configure:
line 11543: awk: command not found
/__w/search-o-o/search-o-o/.bundle/ruby/3.2.0/gems/ffi-1.15.5/ext/ffi_c/libffi/configure:
line 12068: awk: command not found
/__w/search-o-o/search-o-o/.bundle/ruby/3.2.0/gems/ffi-1.15.5/ext/ffi_c/libffi/configure:
line 16045: awk: command not found
/__w/search-o-o/search-o-o/.bundle/ruby/3.2.0/gems/ffi-1.15.5/ext/ffi_c/libffi/configure:
line 19011: -F.: command not found
/__w/search-o-o/search-o-o/.bundle/ruby/3.2.0/gems/ffi-1.15.5/ext/ffi_c/libffi/configure:
line 19203: test: -ge: unary operator expected
configure: WARNING: === Linker version  is too old for
configure: WARNING: === full symbol versioning support in this release of GCC.
configure: WARNING: === You would need to upgrade your binutils to version
configure: WARNING: === 21400 or later and rebuild GCC.
/__w/search-o-o/search-o-o/.bundle/ruby/3.2.0/gems/ffi-1.15.5/ext/ffi_c/libffi/configure:
line 19219: test: -ge: unary operator expected
configure: WARNING: === Symbol versioning will be disabled.
./config.status: line 1364: awk: command not found
config.status: error: could not create include/Makefile
make: *** [libffi.mk:8:
"/__w/search-o-o/search-o-o/.bundle/ruby/3.2.0/gems/ffi-1.15.5/ext/ffi_c/libffi-x86_64-linux-gnu"/.libs/libffi_convenience.a]
Error 1

make failed, exit code 2

Gem files will remain installed in
/__w/search-o-o/search-o-o/.bundle/ruby/3.2.0/gems/ffi-1.15.5 for inspection.
```
or is it actually `awk` that is missing, that makes no sense though, isnt `gawk` installed per default?

