### PR TITLE
Revert "Bump nokogiri from 1.18.9 to 1.19.1"

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -67,7 +67,7 @@ GEM
     locale (2.1.3)
     mercenary (0.4.0)
     mini_portile2 (2.8.9)
-    nokogiri (1.19.1)
+    nokogiri (1.18.9)
       mini_portile2 (~> 2.8.2)
       racc (~> 1.4)
     ox (2.14.16)


### PR DESCRIPTION
Reverts openSUSE/search-o-o#73

nokogiri-1.19.1 requires ruby version >= 3.2, but we deploy on a server that still has 3.1.6